### PR TITLE
Add checks for asg_deploy_name variable

### DIFF
--- a/tasks/clean-up.yml
+++ b/tasks/clean-up.yml
@@ -1,4 +1,6 @@
 ---
+  - fail: msg="asg_deploy_name must be populated for cleanup step"
+    when: asg_deploy_name is undefined or asg_deploy_name == ""
 
   - name: remove new autoscaling group from temp load balancer
     command: aws autoscaling --region "{{ asg_deploy_aws_region }}" detach-load-balancers --auto-scaling-group-name "{{asg_deploy_uuid}}" --load-balancer-names "{{ asg_deploy_temp_elb_name }}"

--- a/tasks/go-live.yml
+++ b/tasks/go-live.yml
@@ -1,4 +1,6 @@
 ---
+  - fail: msg="asg_deploy_name must be populated for go-live step"
+    when: asg_deploy_name is undefined or asg_deploy_name == ""
 
   - name: add autoscaling group to load balancer
     command: aws autoscaling --region "{{ asg_deploy_aws_region }}" attach-load-balancers --auto-scaling-group-name "{{ asg_deploy_uuid }}" --load-balancer-names "{{ item }}"


### PR DESCRIPTION
The go-live and cleanup steps remove resources based on a regex pattern that
looks like this:
`{{asg_deploy_name}}.*`

If that variable is unintentionally overriden with an empty string outside the
role the pattern will match `.*` leading to unexpected asg, elb, and lc deletions/updates.

This check ensures that some value is set on the variable. If not it will fail
before doing damage.
